### PR TITLE
Fix brand name for cherry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by [Recordurbate](https://github.com/oliverjrose99/Recordurbate)
 | Cams.com       | `CC`         |                             |                        | Currently only 360p   |
 | CamSoda        | `CS`         |                             |                        | Yes                   |
 | Chaturbate     | `CB`         |                             |                        | Yes                   |
-| Cherry.TV      | `CHTV`       |                             |                        | Yes                   |
+| Cherry.tv      | `CHTV`       |                             |                        | Yes                   |
 | Dreamcam VR    | `DCVR`       |                             |                        | No                    |
 | Flirt4Free     | `F4F`        |                             |                        | Yes                   |
 | ManyVids Live  | `MV`         |                             |                        | Yes                   |


### PR DESCRIPTION
We here at Cherry.tv have settled on "Cherry.tv", with lowercase "tv," for our branding.