### PR TITLE
Added a configuration for the video file extension

### DIFF
--- a/parameters.py
+++ b/parameters.py
@@ -11,3 +11,10 @@ WANTED_RESOLUTION = 1080
 # Possible values: exact, exact_or_least_higher, exact_or_highest_lower, closest
 # Beware of the exact policy. Nothing gets downloaded if the wanted resolution is not available
 WANTED_RESOLUTION_PREFERENCE = 'closest'
+
+# Video files will be saved with the specified extension.
+# For example, if '.mkv' is used, the file will be saved in the mkv format and you will be able to
+# watch it while it's being downloaded.
+# Also, if someting goes wrong, you will still be able to play the partially downloaded mkv file, 
+# as opposed to a mp4 file.
+VIDEO_FILE_EXTENSION = '.mkv'

--- a/streamonitor/bot.py
+++ b/streamonitor/bot.py
@@ -10,7 +10,7 @@ import requests
 import requests.cookies
 
 import streamonitor.log as log
-from parameters import DOWNLOADS_DIR, DEBUG, WANTED_RESOLUTION, WANTED_RESOLUTION_PREFERENCE
+from parameters import DOWNLOADS_DIR, DEBUG, WANTED_RESOLUTION, WANTED_RESOLUTION_PREFERENCE, VIDEO_FILE_EXTENSION
 from streamonitor.downloaders.ffmpeg import getVideoFfmpeg
 
 
@@ -271,7 +271,7 @@ class Bot(Thread):
         if create_dir:
             os.makedirs(folder, exist_ok=True)
         now = datetime.now()
-        filename = os.path.join(folder, self.username + '-' + str(now.strftime("%Y%m%d-%H%M%S")) + '.mp4')
+        filename = os.path.join(folder, self.username + '-' + str(now.strftime("%Y%m%d-%H%M%S")) + VIDEO_FILE_EXTENSION)
         return filename
 
     def export(self):


### PR DESCRIPTION
By default, if you kill the process downloading the mp4 file (or it exits abruptly for some other reason), you will end with an unplayable video.

Also, most (from my experience) mp4 files cannot be previewed while being downloaded, because of the MOOV atom, which is usually at the end of the file.

The mkv container fixes both of those issues and is handled by ffmpeg without any additional changes or performance drawbacks.