### PR TITLE
Update attributes and playlist-url for MFC

### DIFF
--- a/streamonitor/sites/myfreecams.py
+++ b/streamonitor/sites/myfreecams.py
@@ -25,8 +25,8 @@ class MyFreeCams(Bot):
 
         sid = self.attrs['data-cam-preview-server-id-value']
         mid = 100000000 + int(self.attrs['data-cam-preview-model-id-value'])
-        a = 'a_' if self.attrs['data-cam-preview-is-webrtc-value'] == 'false' else ''
-        playlist_url = f"https://edgevideo.myfreecams.com/hls/NxServer/{sid}/ngrp:mfc_{a}{mid}.f4v_mobile/playlist.m3u8"
+        a = 'a_' if self.attrs['data-cam-preview-is-wzobs-value'] == 'true' else ''
+        playlist_url = f"https://previews.myfreecams.com/hls/NxServer/{sid}/ngrp:mfc_{a}{mid}.f4v_mobile_mhp1080_previewurl/playlist.m3u8"
         r = requests.get(playlist_url)
         if r.status_code != 200:
             return None
@@ -47,7 +47,7 @@ class MyFreeCams(Bot):
             return Bot.Status.NOTEXIST
 
         doc = BeautifulSoup(doc, 'html.parser')
-        params = doc.find(class_='campreview-link')
+        params = doc.find(class_='campreview')
         if params:
             self.attrs = params.attrs
             self.videoUrl = self.getVideoUrl(refresh=True)


### PR DESCRIPTION
MFC updated the class & attributes and changed the playlist-url

Fixes #158 

The only thing that perhaps still needs to be tested: Mfc has added the resolution in the playlist-url with mhp1080. By default mfc uses a url with mhp320 on the share page. 
As far as I have tested, mhp1080 contains all resolutions from 1080p downwards. Whether the url really always exists, I cannot say 100%. In my tests so far it has always worked. Even when streams are only in 720p maximum 