### PR TITLE
Configurable ffmpeg location

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Simply start it in the folder with `docker-compose up`.
 
 ## Configuration
 
-You can set some parameters in the parameters.py.
+You can set some parameters in the [parameters.py](parameters.py).
 
 ## Disclaimer
 

--- a/parameters.py
+++ b/parameters.py
@@ -3,6 +3,9 @@ MIN_FREE_DISK_PERCENT = 1.0  # in %
 DEBUG = False
 HTTP_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0"
 
+# Specify the full path to the ffmpeg binary. By default, ffmpeg found on PATH is used.
+FFMPEG_PATH = 'ffmpeg'
+
 # You can enter a number to select a specific height.
 # Use a huge number here and closest match to get the highest resolution variant
 # Eg: 240, 360, 480, 720, 1080, 1440, 99999

--- a/streamonitor/downloaders/ffmpeg.py
+++ b/streamonitor/downloaders/ffmpeg.py
@@ -4,12 +4,12 @@ import sys
 
 import requests.cookies
 from threading import Thread
-from parameters import DEBUG, SEGMENT_TIME, CONTAINER
+from parameters import DEBUG, SEGMENT_TIME, CONTAINER, FFMPEG_PATH
 
 
 def getVideoFfmpeg(self, url, filename):
     cmd = [
-        'ffmpeg',
+        FFMPEG_PATH,
         '-user_agent', self.headers['User-Agent']
     ]
 


### PR DESCRIPTION
due to all the problems with ffmpeg versions, it seemed practical to me to make the ffmpeg location configurable. 

Even without the trouble, it's handy to not have the ffmpeg in path or system installed. I use the old 4.4.1 for streamonitor, but for other stuff i have a recent ffmpeg version in path