### PR TITLE
Vr cam info in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Simply start it in the folder with `docker-compose up`.
 
 ## Configuration
 
-You can set some parameters in the parameters.py.
+You can set some parameters in the [parameters.py](parameters.py).
 
 ## Disclaimer
 

--- a/parameters.py
+++ b/parameters.py
@@ -3,6 +3,9 @@ MIN_FREE_DISK_PERCENT = 1.0  # in %
 DEBUG = False
 HTTP_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0"
 
+# Specify the full path to the ffmpeg binary. By default, ffmpeg found on PATH is used.
+FFMPEG_PATH = 'ffmpeg'
+
 # You can enter a number to select a specific height.
 # Use a huge number here and closest match to get the highest resolution variant
 # Eg: 240, 360, 480, 720, 1080, 1440, 99999

--- a/streamonitor/bot.py
+++ b/streamonitor/bot.py
@@ -60,6 +60,12 @@ class Bot(Thread):
         Status.RESTRICTED: "Model is restricted, maybe geo-block"
     }
 
+    frame_format_map = {
+        'FISHEYE': 'F',
+        'PANORAMIC': 'P',
+        'CIRCULAR': 'C',
+    }
+
     def __init__(self, username):
         super().__init__()
         self.username = username
@@ -161,7 +167,8 @@ class Bot(Thread):
                                 self._sleep(self.sleep_on_error)
                                 continue
                             self.log('Started downloading show')
-                            ret = self.getVideo(self, video_url, self.genOutFilename())
+                            os.makedirs(self.outputFolder, exist_ok=True)
+                            ret = self.getVideo(self)
                             if not ret:
                                 self.sc = self.Status.ERROR
                                 self.log(self.status())
@@ -279,14 +286,6 @@ class Bot(Thread):
     def outputFolder(self):
         return os.path.join(DOWNLOADS_DIR, self.username + ' [' + self.siteslug + ']')
 
-    def genOutFilename(self, create_dir=True):
-        folder = self.outputFolder
-        if create_dir:
-            os.makedirs(folder, exist_ok=True)
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        filename = os.path.join(folder, f'{self.username}-{timestamp}.{CONTAINER}')
-        return filename
-
     def export(self):
         return {"site": self.site, "username": self.username, "running": self.running}
 
@@ -303,3 +302,13 @@ class Bot(Thread):
     def createInstance(username: str, site: str = None):
         if site:
             return Bot.str2site(site)(username)
+
+    def vrFilenamePart(self):
+        return ""
+
+    def filename(self):
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        return os.path.join(self.outputFolder, f'{self.username}{self.vrFilenamePart()}-{timestamp}.{CONTAINER}')
+
+    def filenameSegmented(self):
+        return os.path.join(self.outputFolder, f'{self.username}{self.vrFilenamePart()}-%Y%m%d-%H%M%S.{CONTAINER}')

--- a/streamonitor/downloaders/ffmpeg.py
+++ b/streamonitor/downloaders/ffmpeg.py
@@ -29,6 +29,17 @@ def getVideoFfmpeg(self, url, filename):
         '-c:v', 'copy',
     ])
 
+    frame_format_map = {
+        'FISHEYE': 'F',
+        'PANORAMIC': 'P',
+        'CIRCULAR': 'C',
+    }
+    
+    vr_suffix = ""
+    vr_cam_settings = self.lastInfo['broadcastSettings']['vrCameraSettings']
+    if vr_cam_settings is not None:
+        vr_suffix = f"_{vr_cam_settings["stereoPacking"]}_{vr_cam_settings["frameFormat"]}{vr_cam_settings["horizontalAngle"]}"
+
     if SEGMENT_TIME is not None:
         username = filename.rsplit('-', maxsplit=2)[0]
         cmd.extend([
@@ -36,13 +47,14 @@ def getVideoFfmpeg(self, url, filename):
             '-reset_timestamps', '1',
             '-segment_time', str(SEGMENT_TIME),
             '-strftime', '1',
-            f'{username}-%Y%m%d-%H%M%S.{CONTAINER}'
+            f'{username}-%Y%m%d-%H%M%S{vr_suffix}.{CONTAINER}'
         ])
     else:
         cmd.extend([
             filename
         ])
 
+    print(cmd)
     class _Stopper:
         def __init__(self):
             self.stop = False

--- a/streamonitor/downloaders/ffmpeg.py
+++ b/streamonitor/downloaders/ffmpeg.py
@@ -4,12 +4,12 @@ import sys
 
 import requests.cookies
 from threading import Thread
-from parameters import DEBUG, SEGMENT_TIME, CONTAINER
+from parameters import DEBUG, SEGMENT_TIME, CONTAINER, FFMPEG_PATH
 
 
 def getVideoFfmpeg(self, url, filename):
     cmd = [
-        'ffmpeg',
+        FFMPEG_PATH,
         '-user_agent', self.headers['User-Agent']
     ]
 

--- a/streamonitor/sites/stripchat_vr.py
+++ b/streamonitor/sites/stripchat_vr.py
@@ -1,3 +1,5 @@
+import os
+
 from streamonitor.sites.stripchat import StripChat
 from streamonitor.bot import Bot
 
@@ -5,6 +7,11 @@ from streamonitor.bot import Bot
 class StripChatVR(StripChat):
     site = 'StripChatVR'
     siteslug = 'SCVR'
+
+    frame_format_map = {
+        'FISHEYE': 'F',
+    #     TODO add other formats
+    }
 
     def __init__(self, username):
         super().__init__(username)
@@ -22,5 +29,13 @@ class StripChatVR(StripChat):
             return Bot.Status.OFFLINE
         return status
 
+    def genOutFilename(self, create_dir=True):
+        default_filename = super().genOutFilename(create_dir)
+        name, ext = os.path.splitext(default_filename)
+        return f"{name}{self.vrSuffix()}{ext}"
+
+    def vrSuffix(self):
+        vr_cam_settings = self.lastInfo['broadcastSettings']['vrCameraSettings']
+        return f"_{vr_cam_settings["stereoPacking"]}_{self.frame_format_map[vr_cam_settings["frameFormat"]]}{vr_cam_settings["horizontalAngle"]}"
 
 Bot.loaded_sites.add(StripChatVR)

--- a/streamonitor/sites/stripchat_vr.py
+++ b/streamonitor/sites/stripchat_vr.py
@@ -1,17 +1,10 @@
-import os
-
-from streamonitor.sites.stripchat import StripChat
 from streamonitor.bot import Bot
+from streamonitor.sites.stripchat import StripChat
 
 
 class StripChatVR(StripChat):
     site = 'StripChatVR'
     siteslug = 'SCVR'
-
-    frame_format_map = {
-        'FISHEYE': 'F',
-    #     TODO add other formats
-    }
 
     def __init__(self, username):
         super().__init__(username)
@@ -29,13 +22,9 @@ class StripChatVR(StripChat):
             return Bot.Status.OFFLINE
         return status
 
-    def genOutFilename(self, create_dir=True):
-        default_filename = super().genOutFilename(create_dir)
-        name, ext = os.path.splitext(default_filename)
-        return f"{name}{self.vrSuffix()}{ext}"
-
-    def vrSuffix(self):
+    def vrFilenamePart(self):
         vr_cam_settings = self.lastInfo['broadcastSettings']['vrCameraSettings']
         return f"_{vr_cam_settings["stereoPacking"]}_{self.frame_format_map[vr_cam_settings["frameFormat"]]}{vr_cam_settings["horizontalAngle"]}"
+
 
 Bot.loaded_sites.add(StripChatVR)


### PR DESCRIPTION
This PR builds upon PR #189 .

The idea is that most VR video players automatically set frame format and projection (+ camera angle) based on parameters found in the filename. This patch facilitates writing these parameters into the filename.

for example:
`username_LR_F135-20250517-012028.mp4`

LR = left/right
F = fisheye
135 = horizontal camera angle

without these parameters, as the viewer you have to setup the player everytime and guess what the camera angle is.