### PR TITLE
Proxy support for outbound requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # unset password (admin by default)
       #STRMNTR_PASSWORD: ''
       # unbind web interface (bound to 127.0.0.1 by default)
-      STRMNTR_HOST: '0.0.0.0'
+      STRMNTR_HOST: "0.0.0.0"
       # change confirm delete behavior: disable
       #STRMNTR_CONFIRM_DEL: ""
       # change confirm delete behavior: always-on

--- a/parameters.py
+++ b/parameters.py
@@ -1,4 +1,6 @@
+import os
 import os.path
+
 import environ
 
 
@@ -13,6 +15,38 @@ DEBUG = env.bool("STRMNTR_DEBUG", False)
 
 # The camsoda bot ignores this setting in favor of a chrome useragent generated with the fake-useragent library
 HTTP_USER_AGENT = env.str("STRMNTR_USER_AGENT", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0")
+
+# Optional proxy configuration for HTTP requests.
+# Examples:
+# STRMNTR_HTTP_PROXY=http://127.0.0.1:8080
+# STRMNTR_HTTPS_PROXY=http://127.0.0.1:8080
+# STRMNTR_ALL_PROXY=socks5://127.0.0.1:9050
+REQUESTS_HTTP_PROXY = env.str("STRMNTR_HTTP_PROXY", "").strip()
+REQUESTS_HTTPS_PROXY = env.str("STRMNTR_HTTPS_PROXY", "").strip()
+REQUESTS_ALL_PROXY = env.str("STRMNTR_ALL_PROXY", "").strip()
+REQUESTS_NO_PROXY = env.str("STRMNTR_NO_PROXY", "").strip()
+
+REQUESTS_PROXIES = {}
+if REQUESTS_HTTP_PROXY:
+    REQUESTS_PROXIES["http"] = REQUESTS_HTTP_PROXY
+if REQUESTS_HTTPS_PROXY:
+    REQUESTS_PROXIES["https"] = REQUESTS_HTTPS_PROXY
+if REQUESTS_ALL_PROXY:
+    REQUESTS_PROXIES.setdefault("http", REQUESTS_ALL_PROXY)
+    REQUESTS_PROXIES.setdefault("https", REQUESTS_ALL_PROXY)
+
+if REQUESTS_HTTP_PROXY:
+    os.environ["HTTP_PROXY"] = REQUESTS_HTTP_PROXY
+    os.environ["http_proxy"] = REQUESTS_HTTP_PROXY
+if REQUESTS_HTTPS_PROXY:
+    os.environ["HTTPS_PROXY"] = REQUESTS_HTTPS_PROXY
+    os.environ["https_proxy"] = REQUESTS_HTTPS_PROXY
+if REQUESTS_ALL_PROXY:
+    os.environ["ALL_PROXY"] = REQUESTS_ALL_PROXY
+    os.environ["all_proxy"] = REQUESTS_ALL_PROXY
+if REQUESTS_NO_PROXY:
+    os.environ["NO_PROXY"] = REQUESTS_NO_PROXY
+    os.environ["no_proxy"] = REQUESTS_NO_PROXY
 
 # Specify the full path to the ffmpeg binary. By default, ffmpeg found on PATH is used.
 FFMPEG_PATH = env.str("STRMNTR_FFMPEG_PATH", 'ffmpeg')

--- a/parameters.py
+++ b/parameters.py
@@ -3,10 +3,9 @@ import os.path
 
 import environ
 
-
 env = environ.Env()
-if os.path.exists('.env'):
-    environ.Env.read_env('.env')
+if os.path.exists(".env"):
+    environ.Env.read_env(".env")
 
 
 DOWNLOADS_DIR = env.str("STRMNTR_DOWNLOAD_DIR", "downloads")
@@ -14,42 +13,44 @@ MIN_FREE_DISK_PERCENT = env.float("STRMNTR_MIN_FREE_SPACE", 5.0)  # in %
 DEBUG = env.bool("STRMNTR_DEBUG", False)
 
 # The camsoda bot ignores this setting in favor of a chrome useragent generated with the fake-useragent library
-HTTP_USER_AGENT = env.str("STRMNTR_USER_AGENT", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0")
+HTTP_USER_AGENT = env.str(
+    "STRMNTR_USER_AGENT",
+    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0",
+)
 
-# Optional proxy configuration for HTTP requests.
-# Examples:
+# Optional Chaturbate diagnostics / Cloudflare clearance support
+# Set a URL that will be fetched through the same session to verify proxy egress IP
+CHB_PROXY_TEST_URL = env.str(
+    "STRMNTR_CB_PROXY_TEST_URL",
+    "https://api.ipify.org?format=json",
+).strip()
+# Optional Cloudflare clearance cookie value for Chaturbate
+CHB_CF_CLEARANCE = env.str("STRMNTR_CB_CF_CLEARANCE", "").strip()
+# Optional Chaturbate-specific User-Agent override. If unset, HTTP_USER_AGENT is used.
+CHB_USER_AGENT = env.str("STRMNTR_CB_USER_AGENT", "").strip()
+
+# Optional proxy configuration for HTTP and HTTPS requests.
+# Example:
 # STRMNTR_HTTP_PROXY=http://127.0.0.1:8080
-# STRMNTR_HTTPS_PROXY=http://127.0.0.1:8080
-# STRMNTR_ALL_PROXY=socks5://127.0.0.1:9050
 REQUESTS_HTTP_PROXY = env.str("STRMNTR_HTTP_PROXY", "").strip()
-REQUESTS_HTTPS_PROXY = env.str("STRMNTR_HTTPS_PROXY", "").strip()
-REQUESTS_ALL_PROXY = env.str("STRMNTR_ALL_PROXY", "").strip()
 REQUESTS_NO_PROXY = env.str("STRMNTR_NO_PROXY", "").strip()
 
 REQUESTS_PROXIES = {}
 if REQUESTS_HTTP_PROXY:
     REQUESTS_PROXIES["http"] = REQUESTS_HTTP_PROXY
-if REQUESTS_HTTPS_PROXY:
-    REQUESTS_PROXIES["https"] = REQUESTS_HTTPS_PROXY
-if REQUESTS_ALL_PROXY:
-    REQUESTS_PROXIES.setdefault("http", REQUESTS_ALL_PROXY)
-    REQUESTS_PROXIES.setdefault("https", REQUESTS_ALL_PROXY)
+    REQUESTS_PROXIES["https"] = REQUESTS_HTTP_PROXY
 
 if REQUESTS_HTTP_PROXY:
     os.environ["HTTP_PROXY"] = REQUESTS_HTTP_PROXY
     os.environ["http_proxy"] = REQUESTS_HTTP_PROXY
-if REQUESTS_HTTPS_PROXY:
-    os.environ["HTTPS_PROXY"] = REQUESTS_HTTPS_PROXY
-    os.environ["https_proxy"] = REQUESTS_HTTPS_PROXY
-if REQUESTS_ALL_PROXY:
-    os.environ["ALL_PROXY"] = REQUESTS_ALL_PROXY
-    os.environ["all_proxy"] = REQUESTS_ALL_PROXY
+    os.environ["HTTPS_PROXY"] = REQUESTS_HTTP_PROXY
+    os.environ["https_proxy"] = REQUESTS_HTTP_PROXY
 if REQUESTS_NO_PROXY:
     os.environ["NO_PROXY"] = REQUESTS_NO_PROXY
     os.environ["no_proxy"] = REQUESTS_NO_PROXY
 
 # Specify the full path to the ffmpeg binary. By default, ffmpeg found on PATH is used.
-FFMPEG_PATH = env.str("STRMNTR_FFMPEG_PATH", 'ffmpeg')
+FFMPEG_PATH = env.str("STRMNTR_FFMPEG_PATH", "ffmpeg")
 
 # You can enter a number to select a specific height.
 # Use a huge number here and closest match to get the highest resolution variant
@@ -59,11 +60,11 @@ WANTED_RESOLUTION = env.int("STRMNTR_RESOLUTION", 1080)
 # Specify match type when specified height
 # Possible values: exact, exact_or_least_higher, exact_or_highest_lower, closest
 # Beware of the exact policy. Nothing gets downloaded if the wanted resolution is not available
-WANTED_RESOLUTION_PREFERENCE = env.str("STRMNTR_RESOLUTION_PREF", 'closest')
+WANTED_RESOLUTION_PREFERENCE = env.str("STRMNTR_RESOLUTION_PREF", "closest")
 
 # Specify output container here
 # Suggested values are 'mkv' or 'mp4'
-CONTAINER = env.str("STRMNTR_CONTAINER", 'mp4')
+CONTAINER = env.str("STRMNTR_CONTAINER", "mp4")
 
 # Add auto-generated VR format suffix to files
 VR_FORMAT_SUFFIX = env.bool("STRMNTR_VR_FORMAT_SUFFIX", True)

--- a/streamonitor/bot.py
+++ b/streamonitor/bot.py
@@ -1,21 +1,29 @@
 from __future__ import unicode_literals
+
 import os
 import traceback
+from datetime import datetime
 from enum import Enum
+from threading import Thread
+from time import sleep
 from urllib.parse import urljoin
 
 import m3u8
-from time import sleep
-from datetime import datetime
-from threading import Thread
-
 import requests
 import requests.cookies
 
-from streamonitor.enums import Status, COUNTRIES, Gender, GENDER_DATA
 import streamonitor.log as log
-from parameters import DOWNLOADS_DIR, DEBUG, WANTED_RESOLUTION, WANTED_RESOLUTION_PREFERENCE, CONTAINER, HTTP_USER_AGENT
+from parameters import (
+    CONTAINER,
+    DEBUG,
+    DOWNLOADS_DIR,
+    HTTP_USER_AGENT,
+    REQUESTS_PROXIES,
+    WANTED_RESOLUTION,
+    WANTED_RESOLUTION_PREFERENCE,
+)
 from streamonitor.downloaders.ffmpeg import getVideoFfmpeg
+from streamonitor.enums import COUNTRIES, GENDER_DATA, Gender, Status
 from streamonitor.models import VideoData
 
 LOADED_SITES = set()
@@ -66,6 +74,8 @@ class Bot(Thread):
 
         self.session = requests.Session()
         self.session.headers.update(self.headers)
+        if REQUESTS_PROXIES:
+            self.session.proxies.update(REQUESTS_PROXIES)
         self.cookies = None
         self.cookieUpdater = None
         self.cookie_update_interval = 0

--- a/streamonitor/sites/chaturbate.py
+++ b/streamonitor/sites/chaturbate.py
@@ -1,41 +1,44 @@
 import re
+
 import requests
+
+from parameters import REQUESTS_PROXIES
 from streamonitor.bot import Bot
-from streamonitor.enums import Status, Gender
+from streamonitor.enums import Gender, Status
 
 
 class Chaturbate(Bot):
-    site = 'Chaturbate'
-    siteslug = 'CB'
+    site = "Chaturbate"
+    siteslug = "CB"
     bulk_update = True
 
     _GENDER_MAP = {
-        'f': Gender.FEMALE,
-        'm': Gender.MALE,
-        's': Gender.TRANS,
-        'c': Gender.BOTH,
+        "f": Gender.FEMALE,
+        "m": Gender.MALE,
+        "s": Gender.TRANS,
+        "c": Gender.BOTH,
     }
 
     def __init__(self, username):
         super().__init__(username)
         self.sleep_on_offline = 30
         self.sleep_on_error = 60
-    
+
     def getWebsiteURL(self):
         return "https://www.chaturbate.com/" + self.username
-    
+
     def getVideoUrl(self):
         if self.bulk_update:
             self.getStatus()
-        url = self.lastInfo['url']
+        url = self.lastInfo["url"]
         if not url:
             return None
-        if self.lastInfo.get('cmaf_edge'):
-            url = url.replace('playlist.m3u8', 'playlist_sfm4s.m3u8')
-            url = re.sub('live-.+amlst', 'live-c-fhls/amlst', url)
+        if self.lastInfo.get("cmaf_edge"):
+            url = url.replace("playlist.m3u8", "playlist_sfm4s.m3u8")
+            url = re.sub("live-.+amlst", "live-c-fhls/amlst", url)
 
         return self.getWantedResolutionPlaylist(url)
-    
+
     @staticmethod
     def _parseStatus(status):
         if status == "public":
@@ -50,12 +53,22 @@ class Chaturbate(Bot):
         data = {"room_slug": self.username, "bandwidth": "high"}
 
         try:
-            r = requests.post("https://chaturbate.com/get_edge_hls_url_ajax/", headers=headers, data=data)
+            r = self.session.post(
+                "https://chaturbate.com/get_edge_hls_url_ajax/",
+                headers=headers,
+                data=data,
+            )
+            self.logger.info(
+                "get_edge_hls_url_ajax response: status=%s content-type=%s body=%s",
+                r.status_code,
+                r.headers.get("Content-Type"),
+                r.text[:1000],
+            )
             self.lastInfo = r.json()
-            status = self._parseStatus(self.lastInfo['room_status'])
-            if status == status.PUBLIC and not self.lastInfo['url']:
+            status = self._parseStatus(self.lastInfo["room_status"])
+            if status == status.PUBLIC and not self.lastInfo["url"]:
                 status = status.RESTRICTED
-        except:
+        except Exception:
             status = Status.RATELIMIT
 
         self.ratelimit = status == Status.RATELIMIT
@@ -69,29 +82,36 @@ class Chaturbate(Bot):
 
         session = requests.Session()
         session.headers.update(cls.headers)
-        r = session.get("https://chaturbate.com/affiliates/api/onlinerooms/?format=json&wm=DkfRj", timeout=10)
+        if REQUESTS_PROXIES:
+            session.proxies.update(REQUESTS_PROXIES)
+        r = session.get(
+            "https://chaturbate.com/affiliates/api/onlinerooms/?format=json&wm=DkfRj",
+            timeout=10,
+        )
 
         try:
             data = r.json()
         except requests.exceptions.JSONDecodeError:
-            print('Failed to parse JSON response')
+            print("Failed to parse JSON response")
             return
-        data_map = {str(model['username']).lower(): model for model in data}
+        data_map = {str(model["username"]).lower(): model for model in data}
 
         for streamer in streamers:
             model_data = data_map.get(streamer.username.lower())
             if not model_data:
                 streamer.setStatus(Status.OFFLINE)
                 continue
-            if model_data.get('gender'):
-                streamer.gender = cls._GENDER_MAP.get(model_data.get('gender'))
-            if model_data.get('country'):
-                streamer.country = model_data.get('country', '').upper()
-            status = cls._parseStatus(model_data['current_show'])
+            if model_data.get("gender"):
+                streamer.gender = cls._GENDER_MAP.get(model_data.get("gender"))
+            if model_data.get("country"):
+                streamer.country = model_data.get("country", "").upper()
+            status = cls._parseStatus(model_data["current_show"])
             if status == status.PUBLIC:
                 if streamer.sc in [status.PUBLIC, Status.RESTRICTED]:
                     continue
                 status = streamer.getStatus()
             if status == Status.UNKNOWN:
-                print(f'[{streamer.siteslug}] {streamer.username}: Bulk update got unknown status: {status}')
+                print(
+                    f"[{streamer.siteslug}] {streamer.username}: Bulk update got unknown status: {status}"
+                )
             streamer.setStatus(status)

--- a/streamonitor/sites/chaturbate.py
+++ b/streamonitor/sites/chaturbate.py
@@ -2,7 +2,12 @@ import re
 
 import requests
 
-from parameters import REQUESTS_PROXIES
+from parameters import (
+    CHB_CF_CLEARANCE,
+    CHB_PROXY_TEST_URL,
+    CHB_USER_AGENT,
+    REQUESTS_PROXIES,
+)
 from streamonitor.bot import Bot
 from streamonitor.enums import Gender, Status
 
@@ -23,6 +28,18 @@ class Chaturbate(Bot):
         super().__init__(username)
         self.sleep_on_offline = 30
         self.sleep_on_error = 60
+        self._proxy_test_logged = False
+
+        if CHB_USER_AGENT:
+            self.session.headers["User-Agent"] = CHB_USER_AGENT
+
+        if CHB_CF_CLEARANCE:
+            self.session.cookies.set(
+                "cf_clearance",
+                CHB_CF_CLEARANCE,
+                domain=".chaturbate.com",
+                path="/",
+            )
 
     def getWebsiteURL(self):
         return "https://www.chaturbate.com/" + self.username
@@ -48,11 +65,36 @@ class Chaturbate(Bot):
         else:
             return Status.OFFLINE
 
+    def _log_proxy_test(self):
+        if self._proxy_test_logged:
+            return
+
+        self._proxy_test_logged = True
+        try:
+            r = self.session.get(CHB_PROXY_TEST_URL, timeout=10)
+            self.logger.info(
+                "Chaturbate proxy test: proxies=%s user-agent=%s cf_clearance=%s status=%s body=%s",
+                self.session.proxies,
+                self.session.headers.get("User-Agent"),
+                bool(self.session.cookies.get("cf_clearance")),
+                r.status_code,
+                r.text[:500],
+            )
+        except Exception as e:
+            self.logger.info(
+                "Chaturbate proxy test failed: proxies=%s user-agent=%s cf_clearance=%s error=%s",
+                self.session.proxies,
+                self.session.headers.get("User-Agent"),
+                bool(self.session.cookies.get("cf_clearance")),
+                e,
+            )
+
     def getStatus(self):
         headers = {"X-Requested-With": "XMLHttpRequest"}
         data = {"room_slug": self.username, "bandwidth": "high"}
 
         try:
+            self._log_proxy_test()
             r = self.session.post(
                 "https://chaturbate.com/get_edge_hls_url_ajax/",
                 headers=headers,

--- a/streamonitor/sites/sexchathu.py
+++ b/streamonitor/sites/sexchathu.py
@@ -1,73 +1,87 @@
 import time
+
 import requests
+
+from parameters import REQUESTS_PROXIES
 from streamonitor.bot import RoomIdBot
 from streamonitor.enums import Status
 
 
 # Site of Hungarian group AdultPerformerNetwork
 class SexChatHU(RoomIdBot):
-    site = 'SexChatHU'
-    siteslug = 'SCHU'
+    site = "SexChatHU"
+    siteslug = "SCHU"
 
     bulk_update = True
     _performers_list_cache = None
     _performers_list_cache_timestamp = 0
 
-
     @classmethod
     def _getBabesList(cls, force_update=False):
-        if SexChatHU._performers_list_cache_timestamp < time.time() - 60 * 60 or \
-                SexChatHU._performers_list_cache is None or force_update:  # Cache for 1 hour
-            req = requests.get('https://sexchat.hu/ajax/api/roomList/babes', headers=cls.headers)
+        if (
+            SexChatHU._performers_list_cache_timestamp < time.time() - 60 * 60
+            or SexChatHU._performers_list_cache is None
+            or force_update
+        ):  # Cache for 1 hour
+            req = requests.get(
+                "https://sexchat.hu/ajax/api/roomList/babes",
+                headers=cls.headers,
+                proxies=REQUESTS_PROXIES,
+            )
             SexChatHU._performers_list_cache = req.json()
             SexChatHU._performers_list_cache_timestamp = time.time()
 
             for model_data in SexChatHU._performers_list_cache:
-                model_id = model_data['perfid']
+                model_id = model_data["perfid"]
                 model_id = str(model_id)
-                model_id = model_id[1:] if model_id.startswith('v') else model_id
-                model_data['perfid'] = model_id
+                model_id = model_id[1:] if model_id.startswith("v") else model_id
+                model_data["perfid"] = model_id
 
         return SexChatHU._performers_list_cache
 
     def getUsernameFromRoomId(self, room_id):
         for performer in self._getBabesList():
-            if str(performer['perfid']) == room_id:
-                username = performer['screenname']
+            if str(performer["perfid"]) == room_id:
+                username = performer["screenname"]
                 return username
         return None
 
     def getRoomIdFromUsername(self, username):
         for performer in self._getBabesList():
-            if performer['screenname'] == username:
-                room_id = str(performer['perfid'])
+            if performer["screenname"] == username:
+                room_id = str(performer["perfid"])
                 return room_id
         return None
 
     def getWebsiteURL(self):
         if self.room_id is None:
             return super().getWebsiteURL()
-        return "https://sexchat.hu/mypage/" + self.room_id + "/" + self.username + "/chat"
+        return (
+            "https://sexchat.hu/mypage/" + self.room_id + "/" + self.username + "/chat"
+        )
 
     def getVideoUrl(self):
         self.getStatus()
-        return self.getWantedResolutionPlaylist("https:" + self.lastInfo['onlineParams']['modeSpecific']['main']['hls']['address'])
+        return self.getWantedResolutionPlaylist(
+            "https:"
+            + self.lastInfo["onlineParams"]["modeSpecific"]["main"]["hls"]["address"]
+        )
 
     @classmethod
     def _getStatusFromData(cls, data):
         onlinestatus = data.get("onlinestatus") or data.get("onlineStatus")
         if onlinestatus == "free":
-            if 'onlineParams' not in data and 'onlineparams' not in data:
+            if "onlineParams" not in data and "onlineparams" not in data:
                 return Status.UNKNOWN
             onlineparams = data.get("onlineparams") or data.get("onlineParams")
-            if 'modeSpecific' not in onlineparams:
+            if "modeSpecific" not in onlineparams:
                 return Status.UNKNOWN
-            if 'main' not in onlineparams['modeSpecific']:
+            if "main" not in onlineparams["modeSpecific"]:
                 return Status.UNKNOWN
-            if 'hls' not in onlineparams['modeSpecific']['main']:
+            if "hls" not in onlineparams["modeSpecific"]["main"]:
                 return Status.UNKNOWN
             return Status.PUBLIC
-        elif onlinestatus in ['vip', 'group', 'priv']:
+        elif onlinestatus in ["vip", "group", "priv"]:
             return Status.PRIVATE
         elif onlinestatus == "offline":
             return Status.OFFLINE
@@ -77,7 +91,11 @@ class SexChatHU(RoomIdBot):
         if self.room_id is None:
             return Status.NOTEXIST
 
-        r = self.session.get('https://chat.a.apn2.com/chat-api/index.php/room/getRoom?tokenID=guest&roomID=' + self.room_id, headers=self.headers)
+        r = self.session.get(
+            "https://chat.a.apn2.com/chat-api/index.php/room/getRoom?tokenID=guest&roomID="
+            + self.room_id,
+            headers=self.headers,
+        )
         if r.status_code != 200:
             return Status.UNKNOWN
 
@@ -100,7 +118,7 @@ class SexChatHU(RoomIdBot):
         babes_list = cls._getBabesList()
         if not babes_list:
             return
-        data_map = {model['perfid']: model for model in babes_list}
+        data_map = {model["perfid"]: model for model in babes_list}
 
         for model_id, streamer in model_ids.items():
             model_data = data_map.get(model_id)

--- a/streamonitor/sites/stripchat.py
+++ b/streamonitor/sites/stripchat.py
@@ -1,33 +1,37 @@
+import base64
+import hashlib
 import itertools
 import json
 import os.path
 import random
 import re
-import requests
-import base64
-import hashlib
 
+import requests
+
+from parameters import REQUESTS_PROXIES
 from streamonitor.bot import RoomIdBot
 from streamonitor.downloaders.hls import getVideoNativeHLS
-from streamonitor.enums import Status, Gender, COUNTRIES
+from streamonitor.enums import COUNTRIES, Gender, Status
 
 
 class StripChat(RoomIdBot):
-    site = 'StripChat'
-    siteslug = 'SC'
+    site = "StripChat"
+    siteslug = "SC"
 
     bulk_update = True
     _static_data = None
-    _mouflon_cache_filename = 'stripchat_mouflon_keys.json'
+    _mouflon_cache_filename = "stripchat_mouflon_keys.json"
     _mouflon_keys: dict = None
     _cached_keys: dict[str, bytes] = None
-    _PRIVATE_STATUSES = frozenset(["private", "groupShow", "p2p", "virtualPrivate", "p2pVoice"])
+    _PRIVATE_STATUSES = frozenset(
+        ["private", "groupShow", "p2p", "virtualPrivate", "p2pVoice"]
+    )
     _OFFLINE_STATUSES = frozenset(["off", "idle"])
 
     _GENDER_MAP = {
-        'female': Gender.FEMALE,
-        'male': Gender.MALE,
-        'maleFemale': Gender.BOTH
+        "female": Gender.FEMALE,
+        "male": Gender.MALE,
+        "maleFemale": Gender.BOTH,
     }
 
     if os.path.exists(_mouflon_cache_filename):
@@ -36,9 +40,9 @@ class StripChat(RoomIdBot):
                 if not isinstance(_mouflon_keys, dict):
                     _mouflon_keys = {}
                 _mouflon_keys.update(json.load(f))
-                print('Loaded StripChat mouflon key cache')
+                print("Loaded StripChat mouflon key cache")
             except Exception as e:
-                print('Error loading mouflon key cache:', e)
+                print("Error loading mouflon key cache:", e)
 
     def __init__(self, username, room_id=None):
         if StripChat._static_data is None:
@@ -46,59 +50,74 @@ class StripChat(RoomIdBot):
             try:
                 self.getInitialData()
             except Exception as e:
-                print('Error initializing StripChat static data:', e)
+                print("Error initializing StripChat static data:", e)
 
         super().__init__(username, room_id)
         self._id = None
         self.vr = False
-        self.getVideo = lambda _, url, filename: getVideoNativeHLS(self, url, filename, StripChat.m3u_decoder)
+        self.getVideo = lambda _, url, filename: getVideoNativeHLS(
+            self, url, filename, StripChat.m3u_decoder
+        )
 
     @classmethod
     def getInitialData(cls):
         session = requests.Session()
-        r = session.get('https://stripchat.com/api/front/v3/config/static', headers=cls.headers)
+        if REQUESTS_PROXIES:
+            session.proxies.update(REQUESTS_PROXIES)
+        r = session.get(
+            "https://stripchat.com/api/front/v3/config/static", headers=cls.headers
+        )
         if r.status_code != 200:
             raise Exception("Failed to fetch static data from StripChat")
-        StripChat._static_data = r.json().get('static')
+        StripChat._static_data = r.json().get("static")
 
     @classmethod
     def m3u_decoder(cls, content):
-        _mouflon_filename = 'media.mp4'
+        _mouflon_filename = "media.mp4"
 
         def _decode(encrypted_b64: str, key: str) -> str:
             if cls._cached_keys is None:
                 cls._cached_keys = {}
-            hash_bytes = cls._cached_keys[key] if key in cls._cached_keys \
-                else cls._cached_keys.setdefault(key, hashlib.sha256(key.encode("utf-8")).digest())
+            hash_bytes = (
+                cls._cached_keys[key]
+                if key in cls._cached_keys
+                else cls._cached_keys.setdefault(
+                    key, hashlib.sha256(key.encode("utf-8")).digest()
+                )
+            )
             encrypted_data = base64.b64decode(encrypted_b64 + "==")
-            return bytes(a ^ b for (a, b) in zip(encrypted_data, itertools.cycle(hash_bytes))).decode("utf-8")
+            return bytes(
+                a ^ b for (a, b) in zip(encrypted_data, itertools.cycle(hash_bytes))
+            ).decode("utf-8")
 
         psch, pkey, pdkey = StripChat._getMouflonFromM3U(content)
 
-        if psch == 'v1':
+        if psch == "v1":
             _mouflon_file_attr = "#EXT-X-MOUFLON:FILE:"
-        elif psch == 'v2':
+        elif psch == "v2":
             _mouflon_file_attr = "#EXT-X-MOUFLON:URI:"
         else:
             return None
 
-        decoded = ''
+        decoded = ""
         lines = content.splitlines()
         last_decoded_file = None
         for line in lines:
             if line.startswith(_mouflon_file_attr):
-                if psch == 'v1':
-                    last_decoded_file = _decode(line[len(_mouflon_file_attr):], pdkey)
-                elif psch == 'v2':
-                    uri = line[len(_mouflon_file_attr):]
-                    encoded_part = uri.split('_')[-2]
+                if psch == "v1":
+                    last_decoded_file = _decode(line[len(_mouflon_file_attr) :], pdkey)
+                elif psch == "v2":
+                    uri = line[len(_mouflon_file_attr) :]
+                    encoded_part = uri.split("_")[-2]
                     decoded_part = _decode(encoded_part[::-1], pdkey)
-                    last_decoded_file = uri.replace(encoded_part, decoded_part).split('/', maxsplit=4)[4]
+                    last_decoded_file = uri.replace(encoded_part, decoded_part).split(
+                        "/", maxsplit=4
+                    )[4]
             elif line.endswith(_mouflon_filename) and last_decoded_file:
-                decoded += (line.replace(_mouflon_filename, last_decoded_file)) + '\n'
+                decoded += (line.replace(_mouflon_filename, last_decoded_file)) + "\n"
                 last_decoded_file = None
             else:
-                decoded += line + '\n'
+                decoded += line + "\n"
         return decoded
 
     @classmethod
@@ -113,11 +132,15 @@ class StripChat(RoomIdBot):
     @staticmethod
     def _getMouflonFromM3U(m3u8_doc):
         _start = 0
-        _needle = '#EXT-X-MOUFLON:'
+        _needle = "#EXT-X-MOUFLON:"
         while _needle in (_doc := m3u8_doc[_start:]):
             _mouflon_start = _doc.find(_needle)
             if _mouflon_start > 0:
-                _mouflon = _doc[_mouflon_start:m3u8_doc.find('\n', _mouflon_start)].strip().split(':')
+                _mouflon = (
+                    _doc[_mouflon_start : m3u8_doc.find("\n", _mouflon_start)]
+                    .strip()
+                    .split(":")
+                )
                 psch = _mouflon[2]
                 pkey = _mouflon[3]
                 pdkey = StripChat.getMouflonDecKey(pkey)
@@ -134,54 +157,59 @@ class StripChat(RoomIdBot):
 
     def getPlaylistVariants(self, url):
         url = "https://edge-hls.{host}/hls/{id}{vr}/master/{id}{vr}{auto}.m3u8".format(
-                host='doppiocdn.' + random.choice(['org', 'com', 'net']),
-                id=self.room_id,
-                vr='_vr' if self.vr else '',
-                auto='_auto' if not self.vr else ''
-            )
+            host="doppiocdn." + random.choice(["org", "com", "net"]),
+            id=self.room_id,
+            vr="_vr" if self.vr else "",
+            auto="_auto" if not self.vr else "",
+        )
         result = self.session.get(url, headers=self.headers, cookies=self.cookies)
         m3u8_doc = result.content.decode("utf-8")
         psch, pkey, pdkey = StripChat._getMouflonFromM3U(m3u8_doc)
         if pdkey is None:
-            self.log(f'Failed to get mouflon decryption key')
+            self.log(f"Failed to get mouflon decryption key")
             return []
         variants = super().getPlaylistVariants(m3u_data=m3u8_doc)
-        return [variant | {'url': f'{variant["url"]}{"&" if "?" in variant["url"] else "?"}psch={psch}&pkey={pkey}'}
-                for variant in variants]
+        return [
+            variant
+            | {
+                "url": f"{variant['url']}{'&' if '?' in variant['url'] else '?'}psch={psch}&pkey={pkey}"
+            }
+            for variant in variants
+        ]
 
     @staticmethod
     def uniq(length=16):
-        chars = ''.join(chr(i) for i in range(ord('a'), ord('z')+1))
-        chars += ''.join(chr(i) for i in range(ord('0'), ord('9')+1))
-        return ''.join(random.choice(chars) for _ in range(length))
+        chars = "".join(chr(i) for i in range(ord("a"), ord("z") + 1))
+        chars += "".join(chr(i) for i in range(ord("0"), ord("9") + 1))
+        return "".join(random.choice(chars) for _ in range(length))
 
     def _getStatusData(self, username):
         r = self.session.get(
-            f'https://stripchat.com/api/front/v2/models/username/{username}/cam?uniq={StripChat.uniq()}',
-            headers=self.headers
+            f"https://stripchat.com/api/front/v2/models/username/{username}/cam?uniq={StripChat.uniq()}",
+            headers=self.headers,
         )
 
         try:
             data = r.json()
         except requests.exceptions.JSONDecodeError:
-            self.log('Failed to parse JSON response')
+            self.log("Failed to parse JSON response")
             return None
         return data
 
     def _update_lastInfo(self, data):
         if data is None:
             return None
-        if 'cam' not in data:
-            if 'error' in data:
-                error = data['error']
-                if error == 'Not Found':
+        if "cam" not in data:
+            if "error" in data:
+                error = data["error"]
+                if error == "Not Found":
                     return Status.NOTEXIST
-                self.logger.warn(f'Status returned error: {error}')
+                self.logger.warn(f"Status returned error: {error}")
             return Status.UNKNOWN
 
-        self.lastInfo = {'model': data['user']['user']}
-        if isinstance(data['cam'], dict):
-            self.lastInfo |= data['cam']
+        self.lastInfo = {"model": data["user"]["user"]}
+        if isinstance(data["cam"], dict):
+            self.lastInfo |= data["cam"]
         return None
 
     def getRoomIdFromUsername(self, username):
@@ -192,14 +220,14 @@ class StripChat(RoomIdBot):
         if username == self.username:
             self._update_lastInfo(data)
 
-        if 'user' not in data:
+        if "user" not in data:
             return None
-        if 'user' not in data['user']:
+        if "user" not in data["user"]:
             return None
-        if 'id' not in data['user']['user']:
+        if "id" not in data["user"]["user"]:
             return None
 
-        return str(data['user']['user']['id'])
+        return str(data["user"]["user"]["id"])
 
     def getStatus(self):
         data = self._getStatusData(self.username)
@@ -210,31 +238,35 @@ class StripChat(RoomIdBot):
         if error:
             return error
 
-        if 'user' in data and 'user' in data['user']:
-            model_data = data['user']['user']
-            if model_data.get('gender'):
-                self.gender = StripChat._GENDER_MAP.get(model_data.get('gender'))
+        if "user" in data and "user" in data["user"]:
+            model_data = data["user"]["user"]
+            if model_data.get("gender"):
+                self.gender = StripChat._GENDER_MAP.get(model_data.get("gender"))
 
-            if model_data.get('country'):
-                self.country = model_data.get('country', '').upper()
-            elif model_data.get('languages'):
-                for lang in model_data['languages']:
+            if model_data.get("country"):
+                self.country = model_data.get("country", "").upper()
+            elif model_data.get("languages"):
+                for lang in model_data["languages"]:
                     if lang.upper() in COUNTRIES:
                         self.country = lang.upper()
                         break
 
-        status = self.lastInfo['model'].get('status')
-        if status == "public" and self.lastInfo["isCamAvailable"] and self.lastInfo["isCamActive"]:
+        status = self.lastInfo["model"].get("status")
+        if (
+            status == "public"
+            and self.lastInfo["isCamAvailable"]
+            and self.lastInfo["isCamActive"]
+        ):
             return Status.PUBLIC
         if status in self._PRIVATE_STATUSES:
             return Status.PRIVATE
         if status in self._OFFLINE_STATUSES:
             return Status.OFFLINE
-        if self.lastInfo['model'].get('isDeleted') is True:
+        if self.lastInfo["model"].get("isDeleted") is True:
             return Status.NOTEXIST
-        if data['user'].get('isGeoBanned') is True:
+        if data["user"].get("isGeoBanned") is True:
             return Status.RESTRICTED
-        self.logger.warn(f'Got unknown status: {status}')
+        self.logger.warn(f"Got unknown status: {status}")
         return Status.UNKNOWN
 
     @classmethod
@@ -246,32 +278,41 @@ class StripChat(RoomIdBot):
             if streamer.room_id:
                 model_ids[streamer.room_id] = streamer
 
-        base_url = 'https://stripchat.com/api/front/models/list?'
+        base_url = "https://stripchat.com/api/front/models/list?"
         batch_num = 100
         data_map = {}
         model_id_list = list(model_ids)
-        for _batch_ids in [model_id_list[i:i+batch_num] for i in range(0, len(model_id_list), batch_num)]:
+        for _batch_ids in [
+            model_id_list[i : i + batch_num]
+            for i in range(0, len(model_id_list), batch_num)
+        ]:
             session = requests.Session()
             session.headers.update(cls.headers)
-            r = session.get(base_url + '&'.join(f'modelIds[]={model_id}' for model_id in _batch_ids), timeout=10)
+            if REQUESTS_PROXIES:
+                session.proxies.update(REQUESTS_PROXIES)
+            r = session.get(
+                base_url
+                + "&".join(f"modelIds[]={model_id}" for model_id in _batch_ids),
+                timeout=10,
+            )
 
             try:
                 data = r.json()
             except requests.exceptions.JSONDecodeError:
-                print('Failed to parse JSON response')
+                print("Failed to parse JSON response")
                 return
-            data_map |= {str(model['id']): model for model in data.get('models', [])}
+            data_map |= {str(model["id"]): model for model in data.get("models", [])}
 
         for model_id, streamer in model_ids.items():
             model_data = data_map.get(model_id)
             if not model_data:
                 streamer.setStatus(Status.UNKNOWN)
                 continue
-            if model_data.get('gender'):
-                streamer.gender = cls._GENDER_MAP.get(model_data.get('gender'))
-            if model_data.get('country'):
-                streamer.country = model_data.get('country', '').upper()
-            status = model_data.get('status')
+            if model_data.get("gender"):
+                streamer.gender = cls._GENDER_MAP.get(model_data.get("gender"))
+            if model_data.get("country"):
+                streamer.country = model_data.get("country", "").upper()
+            status = model_data.get("status")
             if status == "public" and model_data.get("isOnline"):
                 streamer.setStatus(Status.PUBLIC)
             elif status in cls._PRIVATE_STATUSES:
@@ -279,5 +320,7 @@ class StripChat(RoomIdBot):
             elif status in cls._OFFLINE_STATUSES:
                 streamer.setStatus(Status.OFFLINE)
             else:
-                print(f'[{streamer.siteslug}] {streamer.username}: Bulk update got unknown status: {status}')
+                print(
+                    f"[{streamer.siteslug}] {streamer.username}: Bulk update got unknown status: {status}"
+                )
                 streamer.setStatus(Status.UNKNOWN)

--- a/streamonitor/sites/xlovecam.py
+++ b/streamonitor/sites/xlovecam.py
@@ -1,11 +1,13 @@
 import requests
+
+from parameters import REQUESTS_PROXIES
 from streamonitor.bot import Bot
 from streamonitor.enums import Status
 
 
 class XLoveCam(Bot):
-    site = 'XLoveCam'
-    siteslug = 'XLC'
+    site = "XLoveCam"
+    siteslug = "XLC"
 
     def __init__(self, username):
         super().__init__(username)
@@ -13,60 +15,70 @@ class XLoveCam(Bot):
 
     def getPerformerId(self):
         data = {
-            'config[nickname]':	self.username,
-            'config[favorite]':	"0",
-            'config[recent]': "0",
-            'config[vip]': "0",
-            'config[sort][id]':	"35",
-            'offset[from]':	"0",
-            'offset[length]': "35",
-            'origin': "filter-chg",
-            'stat':	"0",
+            "config[nickname]": self.username,
+            "config[favorite]": "0",
+            "config[recent]": "0",
+            "config[vip]": "0",
+            "config[sort][id]": "35",
+            "offset[from]": "0",
+            "offset[length]": "35",
+            "origin": "filter-chg",
+            "stat": "0",
         }
-        r = requests.post(f'https://www.xlovecam.com/hu/performerAction/onlineList', headers=self.headers, data=data)
+        r = requests.post(
+            f"https://www.xlovecam.com/hu/performerAction/onlineList",
+            headers=self.headers,
+            data=data,
+            proxies=REQUESTS_PROXIES,
+        )
         if not r.ok:
             return None
         resp = r.json()
-        if 'content' not in resp:
+        if "content" not in resp:
             return None
-        if 'performerList' not in resp['content']:
+        if "performerList" not in resp["content"]:
             return None
-        for performer in resp['content']['performerList']:
-            if performer['nickname'].lower() == self.username.lower():
-                return performer['id']
+        for performer in resp["content"]["performerList"]:
+            if performer["nickname"].lower() == self.username.lower():
+                return performer["id"]
         return None
 
     def getVideoUrl(self):
-        return self.lastInfo.get('hlsPlaylistFree')
+        return self.lastInfo.get("hlsPlaylistFree")
 
     def getStatus(self):
         if self._id is None:
             return Status.NOTEXIST
 
         data = {
-            'performerId': self._id,
+            "performerId": self._id,
         }
-        r = requests.post(f'https://www.xlovecam.com/hu/performerAction/getPerformerRoom', headers=self.headers, data=data)
+        r = requests.post(
+            f"https://www.xlovecam.com/hu/performerAction/getPerformerRoom",
+            headers=self.headers,
+            data=data,
+            proxies=REQUESTS_PROXIES,
+        )
 
         if not r.ok:
             return Status.UNKNOWN
-        if 'content' not in r.json():
+        if "content" not in r.json():
             return Status.UNKNOWN
-        if 'performer' not in r.json()['content']:
+        if "performer" not in r.json()["content"]:
             return Status.UNKNOWN
-        self.lastInfo = r.json()['content']['performer']
+        self.lastInfo = r.json()["content"]["performer"]
 
-        if not self.lastInfo.get('enabled'):
+        if not self.lastInfo.get("enabled"):
             return Status.NOTEXIST
-        if self.lastInfo.get('online') == 1:
-            if 'hlsPlaylistFree' not in self.lastInfo:
+        if self.lastInfo.get("online") == 1:
+            if "hlsPlaylistFree" not in self.lastInfo:
                 return Status.UNKNOWN
-            url = self.lastInfo.get('hlsPlaylistFree')
+            url = self.lastInfo.get("hlsPlaylistFree")
             r_m3u = self.session.get(url)
             m3u_data = r_m3u.content
-            if m3u_data.startswith(b'{') or b'EXTM3U' not in m3u_data:
+            if m3u_data.startswith(b"{") or b"EXTM3U" not in m3u_data:
                 return Status.PRIVATE
             return Status.PUBLIC
-        if self.lastInfo.get('online') == 0:
+        if self.lastInfo.get("online") == 0:
             return Status.OFFLINE
         return Status.UNKNOWN


### PR DESCRIPTION
This PR adds configurable proxy support for StreaMonitor’s outbound HTTP traffic and ensures those settings are consistently applied across site integrations.

### Summary
StreaMonitor can now route outbound requests through a configured proxy, including proxies that require authentication. This is useful in environments where direct server IPs are blocked, throttled, or otherwise treated differently by upstream providers.

### What changed
- Added environment-based proxy configuration
- Applied proxy settings to:
  - bot-level `requests.Session` instances
  - standalone `requests.Session()` usage in site modules
  - bare `requests.get()` / `requests.post()` calls where applicable
- Unified proxy configuration so a single `STRMNTR_HTTP_PROXY` value is used for both HTTP and HTTPS requests
- Added optional bypass support via `STRMNTR_NO_PROXY`

### Configuration
Example:

```/dev/null/.env.example#L1-4
STRMNTR_HTTP_PROXY=http://user:password@proxy.example.com:8080
STRMNTR_NO_PROXY=localhost,127.0.0.1
```

### Authentication support
Authenticated proxies are supported by embedding credentials directly in the proxy URL:

```/dev/null/.env.example#L1-2
STRMNTR_HTTP_PROXY=http://user:password@proxy.example.com:8080
```

### Why
Several upstream sites may behave differently depending on the source IP. This change allows deployments to use a proxy without requiring code changes, and fixes cases where some integrations previously bypassed the configured proxy by using direct `requests` calls.

### Notes
- This change is fully optional and backward compatible.
- Existing setups continue to work unchanged if no proxy is configured.
- SOCKS proxies may still require additional dependency support such as `requests[socks]` / `PySocks`, depending on deployment needs.